### PR TITLE
feat: 의약품 검색, 상세조회 api 구현

### DIFF
--- a/controllers/pillController.js
+++ b/controllers/pillController.js
@@ -1,17 +1,45 @@
 const PillService = require('../services/PillService');
+const Pill = require('../models/Pill');
+const { Op } = require('sequelize'); // Sequelize의 Op 가져오기
+
 
 exports.fetch = async (req, res) => {
     const serviceKey = process.env.OPEN_API_SERVICE_KEY;
     const infoUrl = process.env.OPEN_API_INFO_URL;
     const docUrl = process.env.OPEN_API_DOC_URL;
-    
+
     try {
         const savedPillList = await PillService.getPills(serviceKey, infoUrl, docUrl);
-        res.status(200).json({ 
+        res.status(200).json({
             message: '의약품 정보 저장에 성공했습니다.',
             savedPillNumber: savedPillList.length
-         });
+        });
     } catch (error) {
         res.status(500).json({ message: 'Internal Server Error' });
+    }
+};
+
+// 의약품 검색 컨트롤러
+exports.search = async (req, res) => {
+    const { query } = req.query;
+
+    if (!query) {
+        return res.status(400).json({ message: "Internal Server Error" });
+    }
+
+    try {
+        // 검색어를 포함하는 의약품 리스트 조회
+        const pills = await Pill.findAll({
+            where: {
+                item_name: {
+                    [Op.like]: `%${query.trim()}%` // Sequelize의 Op.like를 사용하여 부분 일치를 수행
+                }
+            }
+        });
+
+        res.status(200).json(pills);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ message: "서버 오류", error });
     }
 };

--- a/controllers/pillController.js
+++ b/controllers/pillController.js
@@ -1,5 +1,6 @@
 const PillService = require('../services/PillService');
 const PillSearchDto = require('../dtos/response/PillSearchDto');
+const PillDto = require('../dtos/PillDto');
 const Pill = require('../models/Pill');
 const { Op } = require('sequelize'); // Sequelize의 Op 가져오기
 
@@ -25,7 +26,7 @@ exports.search = async (req, res) => {
     const { query } = req.query;
 
     if (!query) {
-        return res.status(400).json({ message: "Internal Server Error" });
+        return res.status(400).json({ message: "유효하지 않은 검색어입니다." });
     }
 
     try {
@@ -43,12 +44,47 @@ exports.search = async (req, res) => {
             pill.id,
             pill.item_name,
             pill.product_type,
-            pill.big_prdt_img_url 
+            pill.big_prdt_img_url
         ));
 
         res.status(200).json(pillSearchDtos); // DTO 리스트 반환
     } catch (error) {
         console.error(error);
-        res.status(500).json({ message: "서버 오류", error });
+        res.status(500).json({ message: "Internal Server Error", error });
+    }
+};
+
+// 의약품 상세 페이지 API
+exports.getPillById = async (req, res) => {
+    const { id } = req.params; // URL 파라미터에서 id 추출
+
+    try {
+        // ID에 해당하는 의약품 조회
+        const pill = await Pill.findOne({
+            where: {
+                id: id // ID로 검색
+            }
+        });
+
+        // 의약품이 존재하지 않는 경우
+        if (!pill) {
+            return res.status(404).json({ message: "의약품을 찾을 수 없습니다." });
+        }
+
+        // PillDTO 생성
+        const pillDto = new PillDto(
+            pill.item_name,
+            pill.item_ingr_name,
+            pill.product_type,
+            pill.ee_doc_data,
+            pill.ud_doc_data,
+            pill.nb_doc_data,
+            pill.big_prdt_img_url
+        );
+
+        res.status(200).json(pillDto); // PillDTO 반환
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ message: "Internal Server Error", error });
     }
 };

--- a/controllers/pillController.js
+++ b/controllers/pillController.js
@@ -1,4 +1,5 @@
 const PillService = require('../services/PillService');
+const PillSearchDto = require('../dtos/response/PillSearchDto');
 const Pill = require('../models/Pill');
 const { Op } = require('sequelize'); // Sequelize의 Op 가져오기
 
@@ -37,7 +38,15 @@ exports.search = async (req, res) => {
             }
         });
 
-        res.status(200).json(pills);
+        // 필요한 정보를 담은 PillSearchDTO 리스트 생성
+        const pillSearchDtos = pills.map(pill => new PillSearchDto(
+            pill.id,
+            pill.item_name,
+            pill.product_type,
+            pill.big_prdt_img_url 
+        ));
+
+        res.status(200).json(pillSearchDtos); // DTO 리스트 반환
     } catch (error) {
         console.error(error);
         res.status(500).json({ message: "서버 오류", error });

--- a/dtos/response/PillSearchDto.js
+++ b/dtos/response/PillSearchDto.js
@@ -1,0 +1,10 @@
+class PilSearchDto {
+    constructor(id, item_name, product_type, big_prdt_img_url) {
+        this.id = id;
+        this.item_name = item_name;
+        this.product_type = product_type;
+        this.big_prdt_img_url = big_prdt_img_url;
+    }
+}
+
+module.exports = PilSearchDto;

--- a/node_modules/.bin/uuid 2
+++ b/node_modules/.bin/uuid 2
@@ -1,0 +1,1 @@
+../uuid/dist/bin/uuid

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -1,6 +1,5 @@
 const express = require("express");
 const authController = require("../controllers/authController");
-const swaggerCli = require("swagger-cli");
 const router = express.Router();
 
 // 회원가입 라우트

--- a/routes/pillRoutes.js
+++ b/routes/pillRoutes.js
@@ -26,8 +26,127 @@ const router = express.Router();
  */
 router.get("/fetch", pillController.fetch);
 
+/**
+ * @swagger
+ * /pills/search:
+ *   get:
+ *     summary: 의약품 검색
+ *     description: 주어진 검색어를 포함하는 의약품 리스트를 조회합니다.
+ *     parameters:
+ *       - in: query
+ *         name: query
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 검색할 의약품 이름의 키워드입니다.
+ *     responses:
+ *       200:
+ *         description: 검색 결과 반환
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                     description: 의약품 ID
+ *                   item_name:
+ *                     type: string
+ *                     description: 의약품 이름
+ *                   product_type:
+ *                     type: string
+ *                     description: 의약품 효능
+ *                   big_prdt_img_url:
+ *                     type: string
+ *                     description: 의약품 이미지 URL
+ *       400:
+ *         description: 유효하지 않은 검색어
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: 오류 메시지
+ *       500:
+ *         description: 서버 오류
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: 오류 메시지
+ */
 router.get("/search", pillController.search);
 
+/**
+ * @swagger
+ * /pills/{id}:
+ *   get:
+ *     summary: 의약품 상세 정보 조회
+ *     description: 주어진 ID에 해당하는 의약품의 상세 정보를 조회합니다.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: 의약품의 고유 ID입니다.
+ *     responses:
+ *       200:
+ *         description: 의약품 상세 정보 반환
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 item_name:
+ *                   type: string
+ *                   description: 의약품 이름
+ *                 item_ingr_name:
+ *                   type: string
+ *                   description: 의약품 성분 이름
+ *                 product_type:
+ *                   type: string
+ *                   description: 의약품 효능
+ *                 ee_doc_data:
+ *                   type: string
+ *                   description: 효능 효과
+ *                 ud_doc_data:
+ *                   type: string
+ *                   description: 용법 용량
+ *                 nb_doc_data:
+ *                   type: string
+ *                   description: 주의 사항
+ *                 big_prdt_img_url:
+ *                   type: string
+ *                   description: 의약품 이미지 URL
+ *       404:
+ *         description: 의약품을 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: 오류 메시지
+ *       500:
+ *         description: 서버 오류
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: 오류 메시지
+ */
 router.get("/:id", pillController.getPillById);
 
 module.exports = router;

--- a/routes/pillRoutes.js
+++ b/routes/pillRoutes.js
@@ -28,4 +28,6 @@ router.get("/fetch", pillController.fetch);
 
 router.get("/search", pillController.search);
 
+router.get("/:id", pillController.getPillById);
+
 module.exports = router;

--- a/routes/pillRoutes.js
+++ b/routes/pillRoutes.js
@@ -26,4 +26,6 @@ const router = express.Router();
  */
 router.get("/fetch", pillController.fetch);
 
+router.get("/search", pillController.search);
+
 module.exports = router;

--- a/services/PillService.js
+++ b/services/PillService.js
@@ -208,6 +208,23 @@ class PillService {
         return savedPillList; // 성공적으로 저장된 Pill 객체 반환
     }
 
+    // 의약품 검색 서비스 로직
+    /*
+    async search(query) {
+        try {
+            const pills = await Pill.findAll({
+                where: {
+                    item_name: {
+                        [Op.like]: `%${query.trim()}%` // 검색어의 앞뒤 공백 제거 후 부분 일치 검색
+                    }
+                }
+            });
+            return pills;
+        } catch (error) {
+            throw new Error("서버 오류"); // 오류 발생 시 예외 던지기
+        }
+    }
+        */
 
 }
 

--- a/services/PillService.js
+++ b/services/PillService.js
@@ -2,9 +2,9 @@ const sequelize = require('../db'); // db.js에서 Sequelize 인스턴스 가져
 const axios = require('axios');
 
 const xml2js = require('xml2js');
-const PillDTO = require('../dtos/PillDTO');
-const PillInfoDTO = require('../dtos/PillInfoDTO');
-const PillDocDTO = require('../dtos/PillDocDTO');
+const PillDTO = require('../dtos/PillDto');
+const PillInfoDTO = require('../dtos/PillInfoDto');
+const PillDocDTO = require('../dtos/PillDocDto');
 const Pill = require('../models/Pill');
 
 class PillService {
@@ -207,24 +207,6 @@ class PillService {
         //console.log(savedPillList.length);
         return savedPillList; // 성공적으로 저장된 Pill 객체 반환
     }
-
-    // 의약품 검색 서비스 로직
-    /*
-    async search(query) {
-        try {
-            const pills = await Pill.findAll({
-                where: {
-                    item_name: {
-                        [Op.like]: `%${query.trim()}%` // 검색어의 앞뒤 공백 제거 후 부분 일치 검색
-                    }
-                }
-            });
-            return pills;
-        } catch (error) {
-            throw new Error("서버 오류"); // 오류 발생 시 예외 던지기
-        }
-    }
-        */
 
 }
 


### PR DESCRIPTION
의약품 검색, 상세 조회 api 구현

의약품 검색 : 쿼리 파라미터로 검색어 받기
-> item_name에 검색어를 포함하는 의약품 리스트로 반환
-> id, item_name, product_type, big_prdt_img_url 반환 (피그마보고)

의약품 상세 조회 : /pills/:id 엔드포인트를 설정
-> id 가 일치하는  단 1개의 의약품 정보 반환


*주의점*
아직 openApi 호출해서  로컬 디비에 저장하는거 자동으로 안 됨.
pageNo, numOfRows (맞나 변수명?) 조정해서 알아서 db에 몇개의 의약품을 넣고 테스트 해주시면 감사...